### PR TITLE
fix: replace use of deprecated map function

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,5 +2,11 @@ resource "aws_cloudwatch_log_group" "mixmax-log-group" {
   name              = var.name
   retention_in_days = var.retention_period
 
-  tags = merge(var.custom_tags, map("Environment", var.environment), map("Service", var.service))
+  tags = merge(
+    var.custom_tags, 
+    {
+      Environment = var.environment
+      Service     = var.service
+    }
+  )
 }

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ resource "aws_cloudwatch_log_group" "mixmax-log-group" {
   retention_in_days = var.retention_period
 
   tags = merge(
-    var.custom_tags, 
+    var.custom_tags,
     {
       Environment = var.environment
       Service     = var.service


### PR DESCRIPTION
#### Changes Made

To fix compatibility with Terraform 1.0, replace the `map` invocations with a literal map.

This was deprecated in Terraform 0.12, but Terraform 1.0 exists now! 🎉

#### Potential Risks

Y'all might not be on TF > 0.12 yet?

#### Test Plan

`tf validate`